### PR TITLE
update link to Dapper repository

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-DapperWrapper is a library that wraps the [Dapper](http://code.google.com/p/dapper-dot-net/) extension methods on `IDbConnection` to make unit testing easier.
+DapperWrapper is a library that wraps the [Dapper](https://github.com/StackExchange/dapper-dot-net) extension methods on `IDbConnection` to make unit testing easier.
 
 Why bother? Because stubbing the extension methods used in a method-under-unit-test is a pain in the ass. For instance, you can't just use a library like [Moq](http://code.google.com/p/moq/) to stub the `.Query` extension method on a fake `IDbConnection`. To work around this, I introduce a new abstraction, `IDbExecutor`.
 


### PR DESCRIPTION
Update link to Dapper repository to point to GitHub repo rather than the deprecated Google code one.